### PR TITLE
Add links from issue #7; promote numina and quint-llm-kit to top of tooling table

### DIFF
--- a/MORE_LINKS.md
+++ b/MORE_LINKS.md
@@ -50,6 +50,8 @@ See [README.md](./README.md) for curated highlights and project descriptions.
 - [MS Power Platform CAT Kit: plan validation for agent tool use](https://devblogs.microsoft.com/powerplatform/plan-validation-cat-kit/)
 - [Flaw in Gemini CLI allowed code execution via prompt injection](https://arstechnica.com/security/2025/07/flaw-in-gemini-cli-coding-tool-allowed-hackers-to-run-nasty-commands-on-user-devices/)
 - [Code execution through email: exploiting Claude via MCP](https://www.pynt.io/blog/llm-security-blogs/code-execution-through-email-how-i-used-claude-mcp-to-hack-itself)
+- [quint-llm-kit: ready-to-go Docker image for using Claude Code with Quint](https://github.com/informalsystems/quint-llm-kit)
+- [ESBMC agent-marketplace: formal verification for Claude Code — C, C++, Python, Solidity, Java/Kotlin via ESBMC bounded model checker](https://github.com/esbmc/agent-marketplace)
 
 ### Autoformalization and Theorem Proving Research
 
@@ -66,6 +68,7 @@ See [README.md](./README.md) for curated highlights and project descriptions.
 - [LLMLift: verifying LLM-generated code via lifting to proof assistants](https://arxiv.org/abs/2406.03003)
 - [Coq used to resolve the fifth Busy Beaver — formal methods landmark](https://www.quantamagazine.org/amateur-mathematicians-find-fifth-busy-beaver-turing-machine-20240702/)
 - [The Little Prover: introduction to inductive proofs via J-Bob](https://the-little-prover.github.io/)
+- [Intent Formalization Survey — RiSE Group: survey of intent formalization approaches by MSR; instructive introduction to verification for those newer to the field](https://risemsr.github.io/blog/2026-03-05-shuvendu-intent-formalization/)
 
 ### Static Analysis and Code Intelligence
 

--- a/README.md
+++ b/README.md
@@ -87,14 +87,16 @@ Each tool an agent uses (file editors, refactoring operations, search) can be in
 
 | Project | Description |
 |---|---|
+| 🌟 [numina-lean-agent](https://github.com/project-numina/numina-lean-agent) | Agentic Lean proof generation |
+| 🌟 [quint-llm-kit](https://github.com/informalsystems/quint-llm-kit) | Ready-to-go Docker image for using Claude Code with Quint |
 | [LeanCopilot](https://github.com/lean-dojo/LeanCopilot) | LLMs as copilots for theorem proving in Lean |
 | [LeanTool](https://github.com/GasStationManager/LeanTool) | MCP server giving LLMs feedback from Lean |
 | [Provably Correct Vibecoding](https://github.com/GasStationManager/ProvablyCorrectVibeCoding) | Wraps LeanTool for agent-assisted proof development |
-| [numina-lean-agent](https://github.com/project-numina/numina-lean-agent) | Agentic Lean proof generation |
 | [LLMLean](https://github.com/cmu-l3/llmlean) | LLM-powered tactic suggestions in Lean |
 | [LeanAide](https://github.com/siddhartha-gadgil/LeanAide) | AI assistance for Lean development |
 | [ACL2 Jupyter](https://github.com/jimwhite/acl2-jupyter) | ACL2 in Jupyter notebooks |
 | [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent) | Minimal coding agent (~100 lines); tractable target for verification |
+| [ESBMC agent-marketplace](https://github.com/esbmc/agent-marketplace) | Formal verification for Claude Code: bugs, memory safety, and undefined behavior in C, C++, Python, Solidity, Java/Kotlin via ESBMC bounded model checker |
 
 ---
 
@@ -106,6 +108,7 @@ Each tool an agent uses (file editors, refactoring operations, search) can be in
 | [Universalis](https://dl.acm.org/doi/pdf/10.1145/3746223) | AI-first program synthesis framework |
 | [Kimina-Prover Preview](https://github.com/MoonshotAI/Kimina-Prover-Preview) | Large formal reasoning models with reinforcement learning |
 | [AlphaGeometry](https://deepmind.google/discover/blog/alphageometry-an-olympiad-level-ai-system-for-geometry/) | Olympiad-level AI system for geometry |
+| [Intent Formalization Survey — RiSE Group](https://risemsr.github.io/blog/2026-03-05-shuvendu-intent-formalization/) | Survey of intent formalization approaches by MSR's RiSE group; instructive introduction to verification for those newer to the field |
 
 ---
 


### PR DESCRIPTION
Closes #7

## Changes

### README.md — Frameworks & Tooling table
- `numina-lean-agent` moved to the **top** with a 🌟 must-try indicator
- `quint-llm-kit` added at the **top** alongside it, also with 🌟
- `ESBMC agent-marketplace` added as a new entry (formal verification for Claude Code via ESBMC bounded model checker)

### README.md — Research table
- `Intent Formalization Survey — RiSE Group` added (MSR's survey of intent formalization approaches)

### MORE_LINKS.md — Agents and Tools section
- `quint-llm-kit` added
- `ESBMC agent-marketplace` added

### MORE_LINKS.md — Autoformalization and Theorem Proving Research section
- RiSE Group intent formalization survey added