### PR TITLE
Add WASM 1.0 ACL2 formalization plan example

### DIFF
--- a/examples/wasm1-acl2-formalization-plan/ACL2_SEMANTICS_REF.md
+++ b/examples/wasm1-acl2-formalization-plan/ACL2_SEMANTICS_REF.md
@@ -1,0 +1,571 @@
+# ACL2 Semantics Reference for WASM 1.0 Formalization
+
+> Working notes and references for formalizing WASM 1.0 operational semantics
+> in ACL2, extending the Kestrel books (`books/kestrel/wasm/`).
+
+---
+
+## 1. Build & Certification Environment
+
+### ACL2 Installation
+```bash
+# Prerequisites
+sudo apt-get install -y sbcl   # Steel Bank Common Lisp
+
+# Clone & build ACL2
+git clone --depth 1 https://github.com/acl2/acl2.git /opt/acl2
+cd /opt/acl2 && make LISP=sbcl
+export ACL2=/opt/acl2/saved_acl2
+
+# Certify a book (from the books/ directory)
+cd /opt/acl2/books
+ACL2=$ACL2 make USE_QUICKLISP=0 ACL2_CUSTOMIZATION=NONE kestrel/wasm/execution.cert
+```
+
+### Certification Order for Existing Books
+```
+portcullis.lisp         (package definition, via portcullis.acl2 → package.lsp)
+execution.lisp          (core interpreter: ~500 lines, depends on portcullis, bvplus, defaggregate)
+proof-support.lisp      (defopeners for run, nth-local, etc.)
+add-proof.lisp          (proof that add program computes bvplus 32 x y)
+parse-binary.lisp       (~1400 lines, binary format parser, partially complete)
+```
+
+### Headless Agent Certification Pattern
+```bash
+# Certify a single book
+cd /opt/acl2/books
+ACL2=/opt/acl2/saved_acl2 make USE_QUICKLISP=0 ACL2_CUSTOMIZATION=NONE \
+    kestrel/wasm/<bookname>.cert
+
+# Run a test script interactively
+echo '
+(in-package "ACL2")
+(ld "/opt/acl2/books/kestrel/wasm/package.lsp")
+(in-package "WASM")
+(include-book "kestrel/wasm/execution" :dir :system)
+;; ... test code ...
+(quit)
+' | /opt/acl2/saved_acl2
+```
+
+### Test Pattern (assert-event)
+```lisp
+;; Ground-truth execution test (computes concretely, no proofs needed)
+(assert-event
+ (let ((result (run 4
+                    (make-state :store :fake
+                                :call-stack (list (make-frame :return-arity 1
+                                                              :locals (list (make-i32-val 3) (make-i32-val 4))
+                                                              :operand-stack (empty-operand-stack)
+                                                              :instrs '((:local.get 1) (:local.get 0) (:i32.add)))
+                                                  (make-frame :return-arity 0
+                                                              :locals nil
+                                                              :operand-stack (empty-operand-stack)
+                                                              :instrs nil))))))
+   (and (statep result)
+        (equal (top-operand (current-operand-stack result))
+               (make-i32-val 7)))))
+```
+
+---
+
+## 2. WASM 1.0 SpecTec → ACL2 Mapping
+
+### 2.1 Source Files (SpecTec, 2300 lines total)
+
+| SpecTec File | Lines | ACL2 Target | Notes |
+|---|---|---|---|
+| `0-aux.spectec` | 42 | N/A (implicit in ACL2) | Ki=1024, min, sum, concat |
+| `1-syntax.spectec` | 300 | `types.lisp`, `instructions.lisp` | Full AST: types, ops, instructions, modules |
+| `2-syntax-aux.spectec` | 50 | `types.lisp` | size, type projections |
+| `3-numerics.spectec` | 243 | `numerics.lisp` | signed/unsigned, all arith/bitwise/compare/convert ops |
+| `4-runtime.spectec` | 110 | `execution.lisp` (state model) | store, frame, state, admin instrs |
+| `5-runtime-aux.spectec` | 115 | `execution.lisp` (accessors) | State accessors, updaters, grow |
+| `6-typing.spectec` | 456 | `typing.lisp` (phase 5) | Validation/type-checking |
+| `8-reduction.spectec` | 271 | `execution.lisp` (step/execute-*) | Core operational semantics |
+| `9-module.spectec` | 172 | `modules.lisp` | Allocation, instantiation, invocation |
+| `A-binary.spectec` | 541 | `parse-binary.lisp` (exists) | Binary format (partially done) |
+
+### 2.2 SpecTec State Model → ACL2
+
+**SpecTec** (4-runtime.spectec):
+```
+state = store; frame
+config = state; admininstr*
+store = { FUNCS funcinst*, GLOBALS globalinst*, TABLES tableinst*, MEMS meminst* }
+frame = { LOCALS val*, MODULE moduleinst }
+admininstr = instr | CALL_ADDR funcaddr | LABEL_ n {instr*} admininstr* | FRAME_ n {frame} admininstr* | TRAP
+```
+
+**Existing ACL2** (execution.lisp):
+```lisp
+(defaggregate state   ((store storep) (call-stack call-stackp+consp)))
+(defaggregate frame   ((return-arity natp) (locals val-listp) (operand-stack operand-stackp) (instrs instr-listp)))
+;; call-stack = list of frames (implicit FRAME_ nesting)
+;; No LABEL_ handling yet — blocks/loops unimplemented
+```
+
+**Key design decision**: The existing skeleton models execution as a list of
+instructions-to-execute per frame with an explicit call stack, rather than
+SpecTec's admin-instruction stack with nested LABEL_ and FRAME_ contexts.
+
+**For blocks/loops**: Need to extend the frame or add a label stack. Options:
+1. **Add label-stack to frame**: Each frame gets a stack of `(arity . continuation-instrs)` pairs. `br N` pops N labels.
+2. **Flatten to admin instructions**: More faithful to spec but harder to prove things about.
+3. **Hybrid**: Keep instruction pointer + label stack (recommended — matches existing style).
+
+### 2.3 Value Types
+
+**SpecTec**:
+```
+valtype = I32 | I64 | F32 | F64
+val = CONST valtype val_(valtype)
+```
+
+**Existing ACL2** (only i32):
+```lisp
+(defund i32-valp (val)  ;; (:i32.const <u32>)
+(defund valp (val) (or (i32-valp val)))
+```
+
+**Extension needed**:
+```lisp
+;; Add recognizers:
+(defund i64-valp (val) ...)     ;; (:i64.const <u64>)
+(defund f32-valp (val) ...)     ;; (:f32.const <ieee754-32>)
+(defund f64-valp (val) ...)     ;; (:f64.const <ieee754-64>)
+(defund valp (val) (or (i32-valp val) (i64-valp val) (f32-valp val) (f64-valp val)))
+```
+
+### 2.4 Instruction Categories (1-syntax.spectec)
+
+| Category | SpecTec | Count | ACL2 Representation |
+|---|---|---|---|
+| Parametric | NOP, UNREACHABLE, DROP, SELECT | 4 | `(:nop)`, `(:drop)`, etc. |
+| Block | BLOCK bt instr*, LOOP bt instr*, IF bt instr* ELSE instr* | 3 | `(:block bt instrs)`, `(:loop bt instrs)`, `(:if bt then-instrs else-instrs)` |
+| Branch | BR l, BR_IF l, BR_TABLE l* l | 3 | `(:br l)`, `(:br_if l)`, `(:br_table labels default)` |
+| Call | CALL x, CALL_INDIRECT x, RETURN | 3 | `(:call x)`, `(:call_indirect x)`, `(:return)` |
+| Numeric/const | CONST t c | 1 | `(:i32.const n)`, `(:i64.const n)`, `(:f32.const n)`, `(:f64.const n)` |
+| Numeric/unop | i32: CLZ,CTZ,POPCNT; f32/f64: ABS,NEG,SQRT,CEIL,FLOOR,TRUNC,NEAREST | ~10 | `(:i32.clz)`, etc. |
+| Numeric/binop | i32: ADD..ROTR (13); f32/f64: ADD..COPYSIGN (7) | ~20 | `(:i32.add)`, etc. |
+| Numeric/testop | i32: EQZ; i64: EQZ | 2 | `(:i32.eqz)`, `(:i64.eqz)` |
+| Numeric/relop | i32: EQ..GE_U (10); f32/f64: EQ..GE (6) | ~16 | `(:i32.eq)`, etc. |
+| Numeric/cvtop | WRAP, EXTEND, TRUNC, CONVERT, DEMOTE, PROMOTE, REINTERPRET | ~7 sigs | `(:i32.wrap_i64)`, etc. |
+| Local | LOCAL.GET x, LOCAL.SET x, LOCAL.TEE x | 3 | `(:local.get x)`, `(:local.set x)`, `(:local.tee x)` |
+| Global | GLOBAL.GET x, GLOBAL.SET x | 2 | `(:global.get x)`, `(:global.set x)` |
+| Memory | LOAD t, STORE t, MEMORY.SIZE, MEMORY.GROW + packed variants | ~25 | `(:i32.load ao)`, etc. |
+
+### 2.5 Reduction Rules → execute-* Functions
+
+**SpecTec reduction pattern** (8-reduction.spectec):
+```
+rule Step_pure/binop-val:
+  (CONST t c_1) (CONST t c_2) (BINOP t binop)  ~>  (CONST t c)
+  -- if c <- $binop_(t, binop, c_1, c_2)
+```
+
+**ACL2 pattern** (execute-i32.add as template):
+```lisp
+(defun execute-i32.add (state)
+  (b* ((ostack (current-operand-stack state))
+       ((when (not (<= 2 (operand-stack-height ostack)))) :trap)
+       (arg2 (top-operand ostack))
+       (arg1 (top-operand (pop-operand ostack)))
+       ((when (not (and (i32-valp arg1) (i32-valp arg2)))) :trap)
+       (result (i32.add-vals arg1 arg2))
+       (ostack (push-operand result (pop-operand (pop-operand ostack))))
+       (state (update-current-operand-stack ostack state))
+       (state (update-current-instrs (rest (current-instrs state)) state)))
+    state))
+```
+
+---
+
+## 3. Key ACL2 Libraries Used
+
+### Kestrel BV (bitvector) library
+```lisp
+(include-book "kestrel/bv/bvplus" :dir :system)    ; (bvplus 32 x y)
+(include-book "kestrel/bv/bvminus" :dir :system)   ; (bvminus 32 x y)
+(include-book "kestrel/bv/bvmult" :dir :system)    ; (bvmult 32 x y)
+(include-book "kestrel/bv/bvdiv" :dir :system)     ; (bvdiv 32 x y)  — unsigned
+(include-book "kestrel/bv/sbvdiv" :dir :system)    ; (sbvdiv 32 x y) — signed
+(include-book "kestrel/bv/bvmod" :dir :system)     ; (bvmod 32 x y)
+(include-book "kestrel/bv/bvand" :dir :system)     ; (bvand 32 x y)
+(include-book "kestrel/bv/bvor" :dir :system)      ; (bvor 32 x y)
+(include-book "kestrel/bv/bvxor" :dir :system)     ; (bvxor 32 x y)
+(include-book "kestrel/bv/bvnot" :dir :system)     ; (bvnot 32 x)
+(include-book "kestrel/bv/bvsx" :dir :system)      ; (bvsx 64 32 x) — sign-extend
+(include-book "kestrel/bv/bvshl" :dir :system)     ; (bvshl 32 x amt)
+(include-book "kestrel/bv/bvshr" :dir :system)     ; (bvshr 32 x amt)
+(include-book "kestrel/bv/sbvlt-def" :dir :system) ; (sbvlt 32 x y) — signed less-than
+(include-book "kestrel/bv/bool-to-bit" :dir :system)
+```
+
+### Kestrel Utilities
+```lisp
+(include-book "std/util/defaggregate" :dir :system) ; record types
+(include-book "kestrel/utilities/forms" :dir :system)    ; ffn-symb, fargs, farg1
+(include-book "kestrel/utilities/defopeners" :dir :system) ; symbolic execution openers
+```
+
+### SpecTec Numeric Operations → Kestrel BV
+
+| SpecTec | ACL2 BV | Notes |
+|---|---|---|
+| `$iadd_(N, i1, i2)` | `(bvplus N i1 i2)` | |
+| `$isub_(N, i1, i2)` | `(bvminus N i1 i2)` | |
+| `$imul_(N, i1, i2)` | `(bvmult N i1 i2)` | |
+| `$idiv_(N, U, i1, i2)` | `(bvdiv N i1 i2)` | Trap if i2=0 |
+| `$idiv_(N, S, i1, i2)` | `(sbvdiv N i1 i2)` | Trap if i2=0 or overflow |
+| `$irem_(N, U, i1, i2)` | `(bvmod N i1 i2)` | Trap if i2=0 |
+| `$iand_(N, i1, i2)` | `(bvand N i1 i2)` | |
+| `$ior_(N, i1, i2)` | `(bvor N i1 i2)` | |
+| `$ixor_(N, i1, i2)` | `(bvxor N i1 i2)` | |
+| `$inot_(N, i)` | `(bvnot N i)` | |
+| `$ishl_(N, i1, i2)` | `(bvshl N i1 (bvmod N i2 N))` | Shift modulo N |
+| `$ishr_(N, U, i1, i2)` | `(bvshr N i1 (bvmod N i2 N))` | |
+| `$ishr_(N, S, i1, i2)` | Signed shift right | Need to check kestrel/bv library |
+| `$irotl_(N, i1, i2)` | `(rotate-left N i1 (mod i2 N))` | May need custom def |
+| `$irotr_(N, i1, i2)` | `(rotate-right N i1 (mod i2 N))` | May need custom def |
+| `$iclz_(N, i)` | Count leading zeros | May need custom def |
+| `$ictz_(N, i)` | Count trailing zeros | May need custom def |
+| `$ipopcnt_(N, i)` | Population count | May need custom def |
+| `$ieqz_(N, i)` | `(bool-to-bit (= i 0))` | |
+| `$ieq_(N, i1, i2)` | `(bool-to-bit (= i1 i2))` | |
+| `$ilt_(N, U, i1, i2)` | `(bool-to-bit (< i1 i2))` | |
+| `$ilt_(N, S, i1, i2)` | `(bool-to-bit (sbvlt N i1 i2))` | |
+| `$wrap__(64, 32, i)` | `(bvchop 32 i)` | |
+| `$extend__(32, 64, U, i)` | `i` (already unsigned) | |
+| `$extend__(32, 64, S, i)` | `(bvsx 64 32 i)` | |
+
+### Floating-point
+For f32/f64, ACL2 has rational arithmetic but no native IEEE 754. Options:
+1. **Model as rationals** with explicit NaN/Inf tags (like SpecTec's fNmag syntax)
+2. **Use kestrel/bv** to model the bit-level representation
+3. **Defer** (phase 2+) and focus on integer-only programs first
+
+Recommendation: Defer floating-point to Phase 2. The MVP uses only i32 programs.
+
+---
+
+## 4. Control Flow Design
+
+### Labels and Blocks (Critical for MVP)
+
+The SpecTec spec uses admin instructions:
+```
+LABEL_ n {instr*} admininstr*
+```
+Where `n` is the arity, `instr*` is the continuation (where BR jumps to), and
+`admininstr*` is the body being executed.
+
+**Recommended ACL2 design**: Add a `label-stack` to each frame.
+
+```lisp
+(defaggregate label-entry
+  ((arity natp)
+   (continuation instr-listp)))  ; instrs to execute after BR to this label
+
+(defund label-stackp (x) ...)   ; list of label-entry
+
+;; Extend frame:
+(defaggregate frame
+  ((return-arity natp)
+   (locals val-listp)
+   (operand-stack operand-stackp)
+   (instrs instr-listp)
+   (label-stack label-stackp)))  ; NEW: stack of enclosing labels
+```
+
+### Block Execution
+```lisp
+;; BLOCK bt instrs  →  push label with arity=|bt|, continuation=rest-of-instrs, then execute instrs
+;; LOOP bt instrs   →  push label with arity=0, continuation=(LOOP bt instrs) ++ rest-of-instrs
+;; When instrs finish, pop label (fall through)
+;; BR n             →  pop n+1 labels, jump to n-th continuation
+```
+
+### Operand Stack Interaction with Labels
+When entering a block, the operand stack height at entry is recorded.
+When a BR fires, the stack is trimmed back to entry height + arity values.
+
+**Design**: Store `(base-height natp)` in label-entry to track the operand
+stack boundary.
+
+```lisp
+(defaggregate label-entry
+  ((arity natp)
+   (continuation instr-listp)
+   (base-height natp)))  ; operand-stack height at label entry
+```
+
+---
+
+## 5. Store Model (for Globals, Tables, Memory)
+
+### Proper Store (replacing `:fake`)
+```lisp
+(defaggregate store
+  ((funcs func-inst-listp)
+   (globals global-inst-listp)
+   (tables table-inst-listp)
+   (mems mem-inst-listp)))
+
+(defaggregate func-inst
+  ((type functypep)
+   (module module-instp)
+   (code funcp)))
+
+(defaggregate global-inst
+  ((type global-typep)
+   (value valp)))
+
+(defaggregate table-inst
+  ((type table-typep)
+   (refs funcaddr-option-listp)))  ; list of (option funcaddr)
+
+(defaggregate mem-inst
+  ((type mem-typep)
+   (data byte-listp)))  ; linear memory bytes
+```
+
+### Module Instance
+```lisp
+(defaggregate module-inst
+  ((types functype-listp)
+   (funcs funcaddr-listp)
+   (globals globaladdr-listp)
+   (tables tableaddr-listp)
+   (mems memaddr-listp)
+   (exports export-inst-listp)))
+```
+
+### Frame Extension
+```lisp
+;; SpecTec frame = { LOCALS val*, MODULE moduleinst }
+;; Need to add module reference for function calls, globals, etc.
+(defaggregate frame
+  ((return-arity natp)
+   (locals val-listp)
+   (module module-instp)          ; NEW
+   (operand-stack operand-stackp)
+   (instrs instr-listp)
+   (label-stack label-stackp)))   ; NEW
+```
+
+---
+
+## 6. Memory Model (for load/store instructions)
+
+### Byte-addressable linear memory
+- Memory is a flat byte array, initially zero-filled
+- Page size = 64 KiB (65536 bytes)
+- Maximum 2^16 pages = 4 GiB
+- Little-endian byte order
+
+```lisp
+;; Read N bytes from memory at offset
+(defund mem-read-bytes (mem offset n)
+  (declare (xargs :guard (and (byte-listp mem) (natp offset) (natp n))))
+  (take n (nthcdr offset mem)))
+
+;; Write bytes to memory at offset
+(defund mem-write-bytes (mem offset bytes)
+  (declare (xargs :guard (and (byte-listp mem) (natp offset) (byte-listp bytes))))
+  ...)  ; splice bytes into mem at offset
+
+;; Convert between iN values and byte sequences (little-endian)
+(defund i32-to-bytes (val) ...)  ; u32 → 4 bytes LE
+(defund bytes-to-i32 (bytes) ...) ; 4 bytes LE → u32
+```
+
+---
+
+## 7. SpecTec Reduction Rules Reference
+
+### All reduction rules from 8-reduction.spectec:
+
+**Pure reductions** (no state read/write):
+- `unreachable → TRAP`
+- `nop → ε`
+- `val DROP → ε`
+- `val₁ val₂ (CONST I32 c) SELECT → val₁ (if c≠0) | val₂ (if c=0)`
+- `(CONST I32 c) IF bt then ELSE else → BLOCK bt then (if c≠0) | BLOCK bt else (if c=0)`
+- `LABEL_ n {instr'*} val* → val*` (label completed)
+- `val'* val^n (BR 0) instr* → val^n instr'*` (in LABEL_n{instr'*})
+- `val* (BR l+1) instr* → val* (BR l)` (pass through label)
+- `(CONST I32 c) BR_IF l → BR l (if c≠0) | ε (if c=0)`
+- `(CONST I32 i) BR_TABLE l* l' → BR l*[i] (if i<|l*|) | BR l' (if i≥|l*|)`
+- `val LOCAL.TEE x → val val (LOCAL.SET x)`
+- `FRAME_ n {f} val^n → val^n` (frame completed)
+- `val'* val^n RETURN instr* → val^n` (in frame context)
+- `(CONST t c₁) UNOP t unop → (CONST t c) | TRAP`
+- `(CONST t c₁) (CONST t c₂) BINOP t binop → (CONST t c) | TRAP`
+- `(CONST t c₁) TESTOP t testop → (CONST I32 c)`
+- `(CONST t c₁) (CONST t c₂) RELOP t relop → (CONST I32 c)`
+- `(CONST t₁ c₁) CVTOP t₂ t₁ cvtop → (CONST t₂ c) | TRAP`
+- `val* TRAP instr* → TRAP` (trap propagation)
+
+**Read reductions** (read from state but don't modify):
+- `BLOCK t? instr* → LABEL_ n {ε} instr*`
+- `LOOP t? instr* → LABEL_ 0 {LOOP t? instr*} instr*`
+- `CALL x → CALL_ADDR funcaddr[x]`
+- `(CONST I32 i) CALL_INDIRECT x → CALL_ADDR a (or TRAP)`
+- `LOCAL.GET x → local[x]`
+- `GLOBAL.GET x → global[x].VALUE`
+- `(CONST I32 i) LOAD t ao → (CONST t c) | TRAP`
+- `MEMORY.SIZE → (CONST I32 n)`
+
+**State-modifying reductions**:
+- `val LOCAL.SET x → ε` (updates local)
+- `val GLOBAL.SET x → ε` (updates global)
+- `(CONST I32 i) (CONST t c) STORE t ao → ε | TRAP` (updates memory)
+- `(CONST I32 n) MEMORY.GROW → (CONST I32 old_size) | (CONST I32 -1)` (grows memory)
+- `val^k CALL_ADDR a → FRAME_ n {f} (LABEL_ n {ε} instr*)` (creates new frame)
+
+**Context rules**:
+- Steps can occur inside LABEL_ and FRAME_ contexts
+
+---
+
+## 8. Binary Parser Opcodes (parse-binary.lisp coverage)
+
+The existing parser already handles opcodes for most WASM 1.0 instructions,
+mapping binary opcodes to the S-expression representation:
+
+| Byte Range | Category | Status |
+|---|---|---|
+| 0x00-0x11 | Control flow | ✅ Parsed |
+| 0x20-0x24 | Variable (local/global) | ✅ Parsed |
+| 0x28-0x40 | Memory | ✅ Parsed |
+| 0x41-0x42 | i32.const, i64.const | ✅ Parsed |
+| 0x43-0x44 | f32.const, f64.const | ✅ Parsed |
+| 0x45-0xBF | Numeric ops | ✅ Parsed |
+
+The parser is mostly complete; the execution engine is what needs extension.
+
+---
+
+## 9. Proof Patterns (from add-proof.lisp)
+
+### Ground-truth testing
+```lisp
+;; assert-event for concrete execution tests (no proof, just evaluation)
+(assert-event
+ (equal (top-operand (current-operand-stack (run N initial-state)))
+        expected-value))
+```
+
+### Symbolic verification
+```lisp
+;; defthm for symbolic proofs (universal quantification)
+(defthm program-correct
+  (implies (and (u32p x) (u32p y) ...)
+           (equal (top-operand (current-operand-stack (run N (make-state ...))))
+                  (expected-function x y)))
+  :hints (("Goal" :in-theory (enable ...))))
+```
+
+### Opener lemmas
+```lisp
+;; defopeners generates conditional rewrite rules that "open" recursive functions
+;; when the argument structure is known (syntactic check on the term)
+(acl2::defopeners run)
+(acl2::defopeners nth-local)
+```
+
+---
+
+## 10. Key Decisions Log
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| State model | Extend existing skeleton (call-stack + frame) | Compatible with existing proofs; pragmatic |
+| Label/block model | Label stack in frame with base-height tracking | Avoids admin-instruction nesting; cleaner for proofs |
+| Floating-point | Defer to Phase 2 | Integer-only MVP is sufficient |
+| Value representation | S-expressions `(:i32.const n)` | Consistent with existing code |
+| Instruction representation | Keyword S-expressions `(:i32.add)` | Consistent with parser output |
+| Store | Replace `:fake` with proper defaggregate | Required for globals, memory, function calls |
+| BV operations | Use kestrel/bv library | Well-tested, theorem-rich library |
+| Testing | assert-event for concrete + defthm for symbolic | Both patterns proven in existing code |
+
+---
+
+## 11. File Organization Plan
+
+```
+books/kestrel/wasm/
+├── package.lsp              # (exists) WASM package definition
+├── portcullis.lisp          # (exists) portcullis
+├── portcullis.acl2          # (exists) portcullis commands
+├── acl2-customization.lsp   # (exists) customization
+│
+├── types.lisp               # NEW: value types, type recognizers (i32, i64, f32, f64)
+├── numerics.lisp            # NEW: all numeric operations (using kestrel/bv)
+├── store.lisp               # NEW: store, instances, module-inst
+├── execution.lisp           # (exists) EXTEND: state, frame, step, run + all instructions
+├── blocks.lisp              # NEW: label stack, block/loop/if/br execution
+├── memory.lisp              # NEW: memory load/store operations
+├── modules.lisp             # NEW: allocation, instantiation, invocation
+│
+├── parse-binary.lisp        # (exists) binary parser
+│
+├── proof-support.lisp       # (exists) EXTEND: more defopeners
+├── add-proof.lisp           # (exists) add correctness proof
+├── tests.lisp               # NEW: comprehensive assert-event test suite
+├── factorial-proof.lisp     # NEW: factorial example proof
+```
+
+---
+
+## 12. WASM 1.0 Instruction Opcode Quick Reference
+
+### Control (0x00-0x11)
+```
+0x00  unreachable    0x01  nop        0x02  block bt    0x03  loop bt
+0x04  if bt          0x05  else       0x0B  end         0x0C  br l
+0x0D  br_if l        0x0E  br_table   0x0F  return      0x10  call x
+0x11  call_indirect x
+```
+
+### Variable (0x20-0x24)
+```
+0x20  local.get x    0x21  local.set x    0x22  local.tee x
+0x23  global.get x   0x24  global.set x
+```
+
+### Memory (0x28-0x40)
+```
+0x28  i32.load       0x29  i64.load       0x2A  f32.load    0x2B  f64.load
+0x2C  i32.load8_s    0x2D  i32.load8_u    0x2E  i32.load16_s  0x2F  i32.load16_u
+0x30  i64.load8_s    0x31  i64.load8_u    0x32  i64.load16_s  0x33  i64.load16_u
+0x34  i64.load32_s   0x35  i64.load32_u
+0x36  i32.store      0x37  i64.store      0x38  f32.store   0x39  f64.store
+0x3A  i32.store8     0x3B  i32.store16    0x3C  i64.store8  0x3D  i64.store16
+0x3E  i64.store32    0x3F  memory.size    0x40  memory.grow
+```
+
+### Numeric (0x41-0xBF)
+```
+0x41  i32.const n    0x42  i64.const n    0x43  f32.const z  0x44  f64.const z
+0x45  i32.eqz       0x46-0x4F  i32 relops
+0x50  i64.eqz       0x51-0x5A  i64 relops
+0x5B-0x60  f32 relops    0x61-0x66  f64 relops
+0x67-0x78  i32 unops/binops    0x79-0x8A  i64 unops/binops
+0x8B-0x98  f32 unops/binops    0x99-0xA6  f64 unops/binops
+0xA7-0xBF  conversion ops
+```
+
+---
+
+## 13. External References
+
+- **WASM 1.0 SpecTec**: `https://github.com/WebAssembly/spec/tree/main/specification/wasm-1.0`
+- **WASM 1.0 Spec (HTML)**: `https://www.w3.org/TR/wasm-core-1/`
+- **Kestrel WASM books**: `https://github.com/acl2/acl2/tree/master/books/kestrel/wasm`
+- **Kestrel EVM model**: `https://github.com/acl2/acl2/tree/master/books/kestrel/ethereum/evm`
+- **Kestrel BV library**: `https://github.com/acl2/acl2/tree/master/books/kestrel/bv`
+- **ACL2 documentation**: `https://www.cs.utexas.edu/users/moore/acl2/manuals/current/manual/`
+- **defaggregate**: `https://www.cs.utexas.edu/users/moore/acl2/manuals/current/manual/?topic=STD____DEFAGGREGATE`

--- a/examples/wasm1-acl2-formalization-plan/README.md
+++ b/examples/wasm1-acl2-formalization-plan/README.md
@@ -1,0 +1,68 @@
+# WASM 1.0 ACL2 Formalization Plan
+
+An agent-generated plan and reference for formalizing the WASM 1.0 operational semantics in ACL2, extending the [Kestrel Institute's WASM books](https://github.com/acl2/acl2/tree/master/books/kestrel/wasm).
+
+## What This Is
+
+A comprehensive formalization plan and semantics reference document, produced by an AI agent that:
+
+1. **Studied the source material**: The [WASM 1.0 SpecTec formal spec](https://github.com/WebAssembly/spec/tree/main/specification/wasm-1.0) (2300 lines across 10 files) and the existing [Kestrel WASM skeleton](https://github.com/acl2/acl2/blob/master/books/kestrel/wasm/execution.lisp) in ACL2
+2. **Studied related Kestrel models**: The [EVM formalization](https://github.com/acl2/acl2/tree/master/books/kestrel/ethereum/evm) and [JVM execution model](https://github.com/acl2/acl2/tree/master/books/kestrel/jvm) for architectural patterns
+3. **Installed and built ACL2**: Confirmed SBCL + ACL2 8.7+ builds, all existing Kestrel WASM books certify
+4. **Validated the approach**: Ran a concrete execution test (`add(3,4)=7`) through ACL2
+5. **Produced the plan**: 9 milestones from MVP to full formalization, with testing strategy
+
+## Properties Planned for Verification
+
+- **Instruction correctness**: Each WASM 1.0 instruction's ACL2 semantics matches the SpecTec reduction rules
+- **Program proofs**: Symbolic correctness theorems for representative programs (addition, factorial, array sum)
+- **Guard verification**: All ACL2 functions have verified guards (type-safe execution)
+- **Book certification**: Every `.lisp` file certifies through ACL2's proof checker
+
+## Files
+
+| File | Description |
+|---|---|
+| [`WASM1_PLAN.md`](WASM1_PLAN.md) | 9-milestone plan with task bullets, MVP strategy, 16 test programs, testing at 4 levels |
+| [`ACL2_SEMANTICS_REF.md`](ACL2_SEMANTICS_REF.md) | SpecTec → ACL2 mapping, build commands, numeric operation table, control flow design, reduction rule catalogue |
+
+## Model & Agent
+
+- **Model**: Claude claude-sonnet-4-20250514 (via OpenHands agent)
+- **Task prompt**: Study the WASM 1.0 SpecTec and Kestrel WASM skeleton, plan an ACL2 formalization, create milestone plan and semantics reference, install ACL2 and verify the approach
+- **Agent actions**: Cloned repos, read all 10 SpecTec files + 7 Kestrel WASM files + EVM/JVM models, built ACL2, certified 3 books, ran execution test
+
+## Prover & Verification Commands
+
+```bash
+# Install SBCL
+sudo apt-get install -y sbcl
+
+# Clone and build ACL2
+git clone --depth 1 https://github.com/acl2/acl2.git /opt/acl2
+cd /opt/acl2 && make LISP=sbcl
+export ACL2=/opt/acl2/saved_acl2
+
+# Certify existing Kestrel WASM books (confirms build works)
+cd /opt/acl2/books
+ACL2=$ACL2 make USE_QUICKLISP=0 ACL2_CUSTOMIZATION=NONE kestrel/wasm/execution.cert
+ACL2=$ACL2 make USE_QUICKLISP=0 ACL2_CUSTOMIZATION=NONE kestrel/wasm/add-proof.cert
+ACL2=$ACL2 make USE_QUICKLISP=0 ACL2_CUSTOMIZATION=NONE kestrel/wasm/parse-binary.cert
+```
+
+## Verified Baseline
+
+The agent confirmed these existing results before planning:
+
+- ✅ `execution.lisp` certifies (0.67s) — core interpreter with i32.add, local.get
+- ✅ `add-proof.lisp` certifies (0.42s) — symbolic proof: `∀ x y : u32. add(x,y) = bvplus(32,x,y)`
+- ✅ `parse-binary.lisp` certifies (7.29s) — partial WASM binary parser
+- ✅ Concrete test: `run 4` of `[local.get 1, local.get 0, i32.add]` with locals `(3, 4)` yields `(:i32.const 7)`
+
+## Known Gaps
+
+- This is a **plan**, not a completed formalization — no new ACL2 code is included yet
+- Floating-point (f32/f64) IEEE 754 modeling in ACL2 is flagged as high-risk/high-effort
+- Some Kestrel BV library functions for rotate/clz/ctz/popcnt may need custom definitions
+- The label stack design for blocks/loops is proposed but untested
+- The plan assumes the existing skeleton's architecture (explicit call stack) rather than SpecTec's admin-instruction nesting — this is a deliberate design choice for proof ergonomics but diverges from the formal spec's structure

--- a/examples/wasm1-acl2-formalization-plan/WASM1_PLAN.md
+++ b/examples/wasm1-acl2-formalization-plan/WASM1_PLAN.md
@@ -1,0 +1,617 @@
+# WASM 1.0 ACL2 Formalization Plan
+
+> Milestone-driven plan for formalizing the WASM 1.0 operational semantics
+> in ACL2, extending the Kestrel books (`books/kestrel/wasm/`).
+>
+> **Goal**: Produce an executable, certifiable ACL2 semantics for WASM 1.0
+> that runs inside the Kestrel book infrastructure and can verify simple
+> WASM programs end-to-end.
+>
+> **Source of truth**: [WASM 1.0 SpecTec](https://github.com/WebAssembly/spec/tree/main/specification/wasm-1.0)
+> (10 files, 2300 lines of formal spec)
+>
+> **Existing skeleton**: [Kestrel WASM books](https://github.com/acl2/acl2/tree/master/books/kestrel/wasm)
+> (execution.lisp, parse-binary.lisp, add-proof.lisp)
+
+---
+
+## Milestone 0: Environment Bootstrap (Prerequisite)
+
+**Goal**: Headless agent can build ACL2, certify existing books, run tests.
+
+- [ ] Install SBCL (`sudo apt-get install -y sbcl`)
+- [ ] Clone ACL2 (`git clone --depth 1 https://github.com/acl2/acl2.git /opt/acl2`)
+- [ ] Build ACL2 (`cd /opt/acl2 && make LISP=sbcl`)
+- [ ] Set `ACL2=/opt/acl2/saved_acl2`
+- [ ] Certify existing books:
+  ```bash
+  cd /opt/acl2/books
+  ACL2=$ACL2 make USE_QUICKLISP=0 ACL2_CUSTOMIZATION=NONE kestrel/wasm/execution.cert
+  ACL2=$ACL2 make USE_QUICKLISP=0 ACL2_CUSTOMIZATION=NONE kestrel/wasm/add-proof.cert
+  ACL2=$ACL2 make USE_QUICKLISP=0 ACL2_CUSTOMIZATION=NONE kestrel/wasm/parse-binary.cert
+  ```
+- [ ] Clone WASM spec for reference: `git clone --depth 1 --sparse https://github.com/WebAssembly/spec.git && cd spec && git sparse-checkout set specification/wasm-1.0`
+- [ ] Verify test pattern works (assert-event with concrete execution)
+
+**Exit criteria**: All 3 existing `.cert` files build; assert-event test of `run 4` add-program passes.
+
+**Estimated time**: 15 minutes.
+
+---
+
+## Milestone 1: MVP — i32 Arithmetic + Variables + Parametric (Sprint 1)
+
+**Goal**: Execute simple WASM programs using i32 integer arithmetic,
+local variables, and parametric instructions. Enough to run programs
+like addition, max(a,b), conditional swap, and simple loops.
+
+### 1.1 Extend Value Types
+- [ ] Add `i64-valp` recognizer: `(:i64.const <u64>)` with `unsigned-byte-p 64`
+- [ ] Update `valp` to include `i64-valp`
+- [ ] Add `make-i64-val` constructor
+- [ ] Add `val-type` function: extract type tag from a val
+- [ ] Prove `valp` forward-chaining and type-preservation theorems
+
+### 1.2 i32 Arithmetic Operations (SpecTec 3-numerics: `$iadd_` .. `$ipopcnt_`)
+- [ ] `execute-i32.sub` — `(bvminus 32 x y)`
+- [ ] `execute-i32.mul` — `(bvmult 32 x y)`
+- [ ] `execute-i32.div_u` — `(bvdiv 32 x y)`, trap if y=0
+- [ ] `execute-i32.div_s` — `(sbvdiv 32 x y)`, trap if y=0 or overflow
+- [ ] `execute-i32.rem_u` — `(bvmod 32 x y)`, trap if y=0
+- [ ] `execute-i32.rem_s` — signed remainder, trap if y=0
+- [ ] `execute-i32.and` — `(bvand 32 x y)`
+- [ ] `execute-i32.or` — `(bvor 32 x y)`
+- [ ] `execute-i32.xor` — `(bvxor 32 x y)`
+- [ ] `execute-i32.shl` — `(bvshl 32 x (mod y 32))`
+- [ ] `execute-i32.shr_u` — `(bvshr 32 x (mod y 32))`
+- [ ] `execute-i32.shr_s` — signed shift right
+- [ ] `execute-i32.rotl` — rotate left (may need custom def)
+- [ ] `execute-i32.rotr` — rotate right (may need custom def)
+- [ ] `execute-i32.clz` — count leading zeros (custom def)
+- [ ] `execute-i32.ctz` — count trailing zeros (custom def)
+- [ ] `execute-i32.popcnt` — population count (custom def)
+
+### 1.3 i32 Comparison & Test Operations
+- [ ] `execute-i32.eqz` — `(bool-to-bit (= x 0))`, push i32 result
+- [ ] `execute-i32.eq` — `(bool-to-bit (= x y))`
+- [ ] `execute-i32.ne` — `(bool-to-bit (/= x y))`
+- [ ] `execute-i32.lt_u` — `(bool-to-bit (< x y))`
+- [ ] `execute-i32.lt_s` — `(bool-to-bit (sbvlt 32 x y))`
+- [ ] `execute-i32.gt_u`, `gt_s`, `le_u`, `le_s`, `ge_u`, `ge_s`
+
+### 1.4 i32 Constant
+- [ ] `execute-i32.const` — push `(make-i32-val n)` onto operand stack
+
+### 1.5 Local Variable Instructions
+- [ ] `execute-local.set` — pop value, update locals[x]
+  - Add `update-nth-local` function
+  - Add `update-current-locals` state updater
+- [ ] `execute-local.tee` — duplicate top, then local.set
+  (SpecTec: `val (LOCAL.TEE x) ~> val val (LOCAL.SET x)`)
+
+### 1.6 Parametric Instructions
+- [ ] `execute-nop` — no-op, advance instrs
+- [ ] `execute-unreachable` — return `:trap`
+- [ ] `execute-drop` — pop one value from operand stack
+- [ ] `execute-select` — pop condition (i32), pop 2 values, push selected one
+
+### 1.7 Update Instruction Recognizer & Dispatch
+- [ ] Extend `instrp` to recognize all new instruction forms
+- [ ] Extend `execute-instr` case dispatch for all new instructions
+- [ ] Prove `statep-of-execute-instr` for all new cases
+
+### 1.8 Tests for Milestone 1
+- [ ] Test: `3 + 4 = 7` (existing, verify still works)
+- [ ] Test: `10 - 3 = 7`
+- [ ] Test: `6 * 7 = 42`
+- [ ] Test: `10 / 3 = 3` (unsigned)
+- [ ] Test: `10 % 3 = 1`
+- [ ] Test: `0xFF & 0x0F = 0x0F`
+- [ ] Test: `i32.eqz 0 = 1`, `i32.eqz 5 = 0`
+- [ ] Test: `i32.lt_u 3 5 = 1`
+- [ ] Test: `select` with true/false conditions
+- [ ] Test: `local.set` then `local.get` roundtrip
+- [ ] Test: `local.tee` preserves value on stack
+- [ ] Test: `drop` removes top element
+
+**Exit criteria**: All tests pass as assert-events. `execution.lisp` certifies.
+
+**Estimated time**: 2-3 hours.
+
+---
+
+## Milestone 2: Control Flow — Blocks, Loops, Branches (Sprint 2)
+
+**Goal**: Execute programs with structured control flow: if/else,
+loops, and branch instructions. This enables programs like
+factorial, fibonacci, and any bounded loop.
+
+### 2.1 Label Stack Infrastructure
+- [ ] Define `label-entry` aggregate: `(arity, continuation, base-height)`
+- [ ] Define `label-stackp` recognizer
+- [ ] Add `label-stack` field to `frame` aggregate
+- [ ] Update all frame constructors/accessors
+- [ ] Update `make-frame` calls in existing code (add `:label-stack nil`)
+- [ ] Verify existing tests still pass with extended frame
+
+### 2.2 Block Instructions (SpecTec 8-reduction: BLOCK, LOOP, IF)
+- [ ] `execute-block` — push label `(arity=|bt|, continuation=rest-instrs, base=ostack-height)`, set instrs to block body
+- [ ] `execute-loop` — push label `(arity=0, continuation=(loop bt body)++rest-instrs, base=ostack-height)`, set instrs to loop body
+- [ ] `execute-if` — pop i32 condition, dispatch to then-block or else-block (reduce to block)
+- [ ] Handle block completion: when instrs exhaust within a label, pop label, restore instrs to continuation, trim operand stack to base+arity values
+
+### 2.3 Branch Instructions
+- [ ] `execute-br` — pop N+1 labels (for BR N), trim stack, jump to Nth continuation
+  - Special handling: for loops, the continuation re-enters the loop
+- [ ] `execute-br_if` — pop i32 condition; if nonzero do BR, else continue
+- [ ] `execute-br_table` — pop i32 index, lookup in label vector, BR to result
+
+### 2.4 Return Instruction
+- [ ] `execute-return` — like BR that exits all labels + current frame
+  - Pop all labels in current frame, return values to caller
+
+### 2.5 Update step/run for Label Awareness
+- [ ] Modify `step` to handle label completion (no instrs left but labels remain)
+- [ ] Ensure `run` handles the label-popping case
+- [ ] Prove termination still holds (or adjust measure)
+
+### 2.6 Update Instruction Recognizer
+- [ ] `instrp` recognizes `:block`, `:loop`, `:if`, `:br`, `:br_if`, `:br_table`, `:return`
+- [ ] Block/loop/if carry nested instruction lists in their representation
+
+### 2.7 Tests for Milestone 2
+- [ ] Test: simple block with no branch (fall through)
+- [ ] Test: `block` with `br 0` (early exit)
+- [ ] Test: `if/else` true branch
+- [ ] Test: `if/else` false branch
+- [ ] Test: `loop` with `br_if` (count down to 0)
+- [ ] Test: nested blocks with `br 1` (skip outer)
+- [ ] Test: `br_table` dispatch
+- [ ] Test: **factorial(5) = 120** (loop-based implementation)
+  ```wasm
+  ;; factorial(n): uses loop with br_if
+  (local.get 0)  ;; n
+  (i32.const 1)  ;; acc = 1
+  (block (loop
+    (local.get 0)     ;; n
+    (i32.eqz)
+    (br_if 1)         ;; if n==0, exit block
+    (local.get 0)     ;; n
+    (i32.mul)         ;; acc *= n
+    (local.get 0)
+    (i32.const 1)
+    (i32.sub)
+    (local.set 0)     ;; n -= 1
+    (br 0)))          ;; continue loop
+  ```
+- [ ] Test: `return` from nested context
+
+**Exit criteria**: Factorial(5)=120 executes correctly. All block/loop/branch tests pass.
+
+**Estimated time**: 3-4 hours.
+
+---
+
+## Milestone 3: Functions — Call, Call Stack, Store (Sprint 3)
+
+**Goal**: Execute multi-function WASM programs with proper function
+calls, a real store, and module instances.
+
+### 3.1 Proper Store
+- [ ] Define `funcinst` aggregate: `(type, module, code)`
+- [ ] Define `globalinst` aggregate: `(type, value)`
+- [ ] Define `store` aggregate: `(funcs, globals, tables, mems)`
+- [ ] Define `moduleinst` aggregate: `(types, funcs, globals, tables, mems, exports)`
+- [ ] Replace `:fake` store usage with proper store
+
+### 3.2 Frame Module Reference
+- [ ] Add `module` field to `frame` (reference to `moduleinst`)
+- [ ] Update frame accessors for module lookups
+
+### 3.3 Function Call Instructions
+- [ ] `execute-call` — look up function by index, set up new frame
+  - Resolve funcaddr through moduleinst.funcs
+  - Look up funcinst in store.funcs
+  - Pop arguments from caller's operand stack
+  - Initialize locals = args ++ default values for declared locals
+  - Push new frame onto call-stack
+- [ ] `execute-call_indirect` — table-based indirect call
+  - Read funcaddr from table[0].refs[i]
+  - Type-check against expected signature
+  - Proceed as direct call (or trap)
+- [ ] Update `return-from-function` for proper module-aware frames
+
+### 3.4 Global Variable Instructions
+- [ ] `execute-global.get` — read from store.globals[moduleinst.globals[x]].value
+- [ ] `execute-global.set` — write to store (only if mutable global)
+- [ ] State updater for global mutation
+
+### 3.5 Tests for Milestone 3
+- [ ] Test: two-function program (main calls helper)
+- [ ] Test: recursive factorial via `call`
+- [ ] Test: global variable read/write
+- [ ] Test: `call_indirect` with type check
+- [ ] Test: `call_indirect` type mismatch → trap
+
+**Exit criteria**: Multi-function programs execute. Store is fully functional.
+
+**Estimated time**: 3-4 hours.
+
+---
+
+## Milestone 4: Memory — Load, Store, Size, Grow (Sprint 4)
+
+**Goal**: Execute WASM programs that use linear memory.
+
+### 4.1 Memory Infrastructure
+- [ ] Define `meminst` aggregate: `(type, bytes)`
+- [ ] `mem-read-bytes` — read N bytes from memory at offset (bounds-checked)
+- [ ] `mem-write-bytes` — write bytes to memory at offset (bounds-checked)
+- [ ] Little-endian conversion: `i32-to-le-bytes`, `le-bytes-to-i32`, etc.
+- [ ] Add memory to store (initially empty or allocated per module)
+
+### 4.2 Load Instructions
+- [ ] `execute-i32.load` — load 4 bytes at `i + offset`, convert to i32
+- [ ] `execute-i64.load` — load 8 bytes, convert to i64
+- [ ] `execute-i32.load8_s`, `load8_u`, `load16_s`, `load16_u` — packed loads with sign/zero extension
+- [ ] `execute-i64.load8_s` .. `load32_u` — all i64 packed loads
+- [ ] Bounds checking: trap if `i + offset + size > |mem.bytes|`
+
+### 4.3 Store Instructions
+- [ ] `execute-i32.store` — convert to 4 LE bytes, write at `i + offset`
+- [ ] `execute-i64.store` — convert to 8 LE bytes, write
+- [ ] `execute-i32.store8`, `store16` — packed stores (wrap value)
+- [ ] `execute-i64.store8`, `store16`, `store32` — packed stores
+- [ ] Bounds checking for writes
+
+### 4.4 Memory Management
+- [ ] `execute-memory.size` — push `|mem.bytes| / (64*1024)` as i32
+- [ ] `execute-memory.grow` — attempt to grow by N pages
+  - Success: extend bytes with zeros, push old page count
+  - Failure: push -1 (as unsigned i32)
+
+### 4.5 Tests for Milestone 4
+- [ ] Test: store i32, load i32 roundtrip
+- [ ] Test: store i32, load8_u (read single byte)
+- [ ] Test: memory.size returns correct page count
+- [ ] Test: memory.grow then store/load in new region
+- [ ] Test: out-of-bounds load → trap
+- [ ] Test: out-of-bounds store → trap
+- [ ] Test: **sum array** — loop over memory, accumulate i32 values
+
+**Exit criteria**: Memory load/store/grow works. Array sum example executes correctly.
+
+**Estimated time**: 3-4 hours.
+
+---
+
+## Milestone 5: i64 + Conversions (Sprint 5)
+
+**Goal**: Full integer support with 64-bit operations and type conversions.
+
+### 5.1 i64 Operations
+- [ ] All i64 arithmetic: add, sub, mul, div_u, div_s, rem_u, rem_s
+  (mirror i32 implementations with `64` instead of `32`)
+- [ ] All i64 bitwise: and, or, xor, shl, shr_u, shr_s, rotl, rotr, clz, ctz, popcnt
+- [ ] All i64 comparisons: eqz, eq, ne, lt_u, lt_s, gt_u, gt_s, le_u, le_s, ge_u, ge_s
+- [ ] i64.const
+
+### 5.2 Conversion Operations (SpecTec 3-numerics: `$cvtop__`)
+- [ ] `i32.wrap_i64` — `(bvchop 32 x)` (truncate 64→32)
+- [ ] `i64.extend_i32_u` — zero-extend 32→64 (identity on unsigned-byte-p 32)
+- [ ] `i64.extend_i32_s` — `(bvsx 64 32 x)` sign-extend
+- [ ] `i32.trunc_f32_s`, `i32.trunc_f32_u` — (defer if f32 not yet done)
+- [ ] `i32.reinterpret_f32`, `i64.reinterpret_f64` — (defer if float not done)
+- [ ] `f32.reinterpret_i32`, `f64.reinterpret_i64` — (defer if float not done)
+
+### 5.3 Tests for Milestone 5
+- [ ] Test: i64 add, sub, mul
+- [ ] Test: i64 div_u with trap on zero
+- [ ] Test: i64 bit operations
+- [ ] Test: i32.wrap_i64 truncation
+- [ ] Test: i64.extend_i32_s sign extension (negative value)
+- [ ] Test: mixed i32/i64 program
+
+**Exit criteria**: All i32 and i64 operations work. Conversions between them work.
+
+**Estimated time**: 2-3 hours.
+
+---
+
+## Milestone 6: Floating-Point (Sprint 6)
+
+**Goal**: f32 and f64 support.
+
+### 6.1 IEEE 754 Model in ACL2
+- [ ] Define `f32-valp`, `f64-valp` recognizers
+- [ ] Model: either rational-based with explicit NaN/Inf/sign tags,
+  or bit-level model using kestrel/bv (32-bit / 64-bit representations)
+- [ ] Decide on NaN handling strategy (WASM uses canonical NaN propagation)
+
+### 6.2 f32/f64 Operations
+- [ ] Arithmetic: fadd, fsub, fmul, fdiv, fmin, fmax, fcopysign
+- [ ] Unary: fabs, fneg, fsqrt, fceil, ffloor, ftrunc, fnearest
+- [ ] Comparisons: feq, fne, flt, fgt, fle, fge
+
+### 6.3 Remaining Conversions
+- [ ] `i32.trunc_f32_s`, `i32.trunc_f32_u`, `i32.trunc_f64_s`, `i32.trunc_f64_u`
+- [ ] `i64.trunc_f32_s`, `i64.trunc_f32_u`, `i64.trunc_f64_s`, `i64.trunc_f64_u`
+- [ ] `f32.convert_i32_s`, `f32.convert_i32_u`, `f32.convert_i64_s`, `f32.convert_i64_u`
+- [ ] `f64.convert_i32_s`, `f64.convert_i32_u`, `f64.convert_i64_s`, `f64.convert_i64_u`
+- [ ] `f32.demote_f64`, `f64.promote_f32`
+- [ ] Reinterpret operations
+
+### 6.4 Tests
+- [ ] Test: basic f32/f64 arithmetic
+- [ ] Test: NaN propagation
+- [ ] Test: infinity handling
+- [ ] Test: truncation traps (out-of-range float to int)
+
+**Exit criteria**: f32/f64 operations pass concrete tests.
+
+**Estimated time**: 4-6 hours (IEEE 754 modeling is complex).
+
+---
+
+## Milestone 7: Module Instantiation & Binary Integration (Sprint 7)
+
+**Goal**: Parse a `.wasm` binary file and instantiate/execute it.
+
+### 7.1 Module Instantiation (SpecTec 9-module.spectec)
+- [ ] `allocfunc`, `allocglobal`, `alloctable`, `allocmem`
+- [ ] `allocmodule` — full module allocation
+- [ ] `instantiate` — evaluate global initializers, init elem/data segments
+- [ ] `invoke` — entry point for calling an exported function
+
+### 7.2 Binary Parser Integration
+- [ ] Connect `parse-binary.lisp` output to module instantiation
+- [ ] Verify parser output matches expected module structure
+- [ ] End-to-end: read `.wasm` file → parse → instantiate → invoke → result
+
+### 7.3 Table Operations
+- [ ] Elem segment initialization (fill table with function addresses)
+- [ ] call_indirect uses table to resolve function addresses
+
+### 7.4 Import/Export
+- [ ] Export resolution (find exported function by name)
+- [ ] Import stubs (for host functions — model as abstract)
+
+### 7.5 Tests
+- [ ] Test: instantiate a minimal module (one function, no imports)
+- [ ] Test: parse and execute add.wasm
+- [ ] Test: module with memory (data segment initialization)
+- [ ] Test: module with globals (global initializer evaluation)
+- [ ] Test: exported function invocation
+
+**Exit criteria**: Can parse a `.wasm` binary and execute its start function or an exported function.
+
+**Estimated time**: 4-6 hours.
+
+---
+
+## Milestone 8: Proofs & Verification (Sprint 8)
+
+**Goal**: Prove correctness theorems for representative WASM programs.
+
+### 8.1 Proof Infrastructure
+- [ ] Extend `proof-support.lisp` with defopeners for all new functions
+- [ ] Add rewrite rules for common patterns (block completion, branch resolution)
+- [ ] Lemmas for operand-stack manipulation compositionality
+
+### 8.2 Example Proofs
+- [ ] **add-proof.lisp** — verify existing proof still works (regression)
+- [ ] **sub-proof** — subtraction computes bvminus
+- [ ] **max-proof** — max(a,b) using if/else is correct
+- [ ] **factorial-proof** — loop-based factorial computes n!
+  (inductive proof over loop iterations)
+- [ ] **memory-copy-proof** — copying N bytes produces identical sequences
+
+### 8.3 Symbolic Execution Support
+- [ ] Opener rules for new execute-* functions
+- [ ] Conditional rewriting through block/loop structures
+- [ ] Induction schemes for loop proofs
+
+**Exit criteria**: At least 3 non-trivial proofs certified.
+
+**Estimated time**: 4-8 hours.
+
+---
+
+## Milestone 9: Validation / Type Checking (Sprint 9)
+
+**Goal**: Implement WASM type validation rules.
+
+### 9.1 Typing Context (SpecTec 6-typing.spectec)
+- [ ] Define `context` aggregate: types, funcs, globals, tables, mems, locals, labels, return
+- [ ] Limits validation
+- [ ] Function type, global type, table type, memory type validation
+
+### 9.2 Instruction Typing
+- [ ] Type-check each instruction against context
+- [ ] Stack typing (type-check operand stack types)
+- [ ] Block/loop/if typing (labels in context)
+- [ ] Function body typing
+
+### 9.3 Module Validation
+- [ ] Validate all function bodies
+- [ ] Validate imports/exports
+- [ ] Validate memory/table/global constraints
+
+### 9.4 Validation Soundness (stretch goal)
+- [ ] Prove: if a module validates, execution never traps due to type errors
+  (progress + preservation style theorem)
+
+**Exit criteria**: Type checker accepts valid modules, rejects invalid ones.
+
+**Estimated time**: 6-10 hours.
+
+---
+
+## Testing Strategy
+
+### Level 1: Ground-Truth Execution Tests (assert-event)
+Concrete tests that evaluate to a known result. No proof needed —
+ACL2 just computes the answer and checks equality.
+
+```lisp
+(assert-event (equal (result-of-running program) expected-value))
+```
+
+**Coverage**: Every instruction gets at least 2 tests (normal case + edge case/trap).
+
+### Level 2: Symbolic Proofs (defthm)
+Universal properties proven by ACL2's theorem prover.
+
+```lisp
+(defthm add-correct
+  (implies (and (u32p x) (u32p y) ...)
+           (equal (result ...) (bvplus 32 x y))))
+```
+
+**Coverage**: Key programs get symbolic correctness proofs.
+
+### Level 3: Certification (make .cert)
+Every `.lisp` file must certify without errors. This ensures:
+- All guards are verified
+- All theorems are proven
+- No logical inconsistencies
+
+```bash
+ACL2=$ACL2 make USE_QUICKLISP=0 ACL2_CUSTOMIZATION=NONE kestrel/wasm/tests.cert
+```
+
+### Level 4: Regression (CI)
+```bash
+# Certify all WASM books in dependency order
+for book in types numerics store execution blocks memory modules \
+            proof-support tests add-proof factorial-proof; do
+  ACL2=$ACL2 make USE_QUICKLISP=0 ACL2_CUSTOMIZATION=NONE \
+      kestrel/wasm/$book.cert || exit 1
+done
+```
+
+### Test Programs (in order of complexity)
+
+| # | Program | Instrs Used | Milestone |
+|---|---|---|---|
+| 1 | `add(3,4) = 7` | local.get, i32.add | M1 |
+| 2 | `sub(10,3) = 7` | local.get, i32.sub | M1 |
+| 3 | `mul(6,7) = 42` | local.get, i32.mul | M1 |
+| 4 | `div_u(10,3) = 3` | local.get, i32.div_u | M1 |
+| 5 | `is_zero(0) = 1` | local.get, i32.eqz | M1 |
+| 6 | `max(3,5) = 5` | if/else, i32.gt_u | M2 |
+| 7 | `abs(x)` | if/else, i32.sub, i32.lt_s | M2 |
+| 8 | `factorial(5) = 120` | loop, br_if, i32.mul, i32.sub | M2 |
+| 9 | `fibonacci(10) = 55` | loop, local vars, i32.add | M2 |
+| 10 | `gcd(12,8) = 4` | loop, br_if, i32.rem_u | M2 |
+| 11 | `call_helper(3,4)` | call, return | M3 |
+| 12 | `recursive_fact(5)` | call (recursive) | M3 |
+| 13 | `sum_array(mem,n)` | loop, i32.load, memory | M4 |
+| 14 | `memcpy(dst,src,n)` | loop, load, store, memory | M4 |
+| 15 | `i64_add(big1,big2)` | i64.add | M5 |
+| 16 | `parse_and_run(add.wasm)` | binary parse → execute | M7 |
+
+---
+
+## Headless Agent Execution Notes
+
+### Session Setup Script
+```bash
+#!/bin/bash
+# setup-wasm-acl2.sh — Run at start of each agent session
+set -x
+
+# 1. Install SBCL if not present
+which sbcl || sudo apt-get install -y sbcl
+
+# 2. Build ACL2 if not present
+if [ ! -f /opt/acl2/saved_acl2 ]; then
+  git clone --depth 1 https://github.com/acl2/acl2.git /opt/acl2
+  cd /opt/acl2 && make LISP=sbcl
+fi
+export ACL2=/opt/acl2/saved_acl2
+
+# 3. Get WASM spec for reference
+if [ ! -d /opt/wasm-spec ]; then
+  git clone --depth 1 --sparse https://github.com/WebAssembly/spec.git /opt/wasm-spec
+  cd /opt/wasm-spec && git sparse-checkout set specification/wasm-1.0
+fi
+
+# 4. Verify build
+echo '(+ 1 2) (quit)' | $ACL2
+```
+
+### Development Workflow
+```bash
+# Edit a book
+vim /opt/acl2/books/kestrel/wasm/execution.lisp
+
+# Certify it
+cd /opt/acl2/books
+ACL2=$ACL2 make USE_QUICKLISP=0 ACL2_CUSTOMIZATION=NONE kestrel/wasm/execution.cert
+
+# If certification fails, check the log:
+cat /opt/acl2/books/kestrel/wasm/execution.cert.out
+
+# Run an interactive test
+echo '
+(in-package "ACL2")
+(ld "/opt/acl2/books/kestrel/wasm/package.lsp")
+(in-package "WASM")
+(include-book "kestrel/wasm/execution" :dir :system)
+;; your test here
+(quit)
+' | $ACL2
+```
+
+### Common Pitfalls
+1. **Guard verification failures**: Use `:guard-hints` or add type theorems
+2. **Certification timeout**: Break large files into smaller books
+3. **Package issues**: Always `(ld "package.lsp")` before `(in-package "WASM")`
+4. **Stale .cert files**: Delete `.cert` and `.cert.out` before re-certifying
+5. **Include-book paths**: Use `:dir :system` for books under the ACL2 books/ dir
+6. **defaggregate field conflicts**: WASM's `state` shadows ACL2's `state` — handled by package exclusion in `package.lsp`
+
+### Certification Dependency Graph
+```
+package.lsp
+  └── portcullis.lisp
+       ├── types.lisp
+       │    └── numerics.lisp
+       ├── store.lisp
+       ├── execution.lisp ← types, numerics, store
+       │    ├── blocks.lisp
+       │    └── memory.lisp
+       ├── modules.lisp ← execution, store
+       ├── proof-support.lisp ← execution
+       │    ├── add-proof.lisp
+       │    └── factorial-proof.lisp
+       ├── tests.lisp ← execution, blocks, memory
+       └── parse-binary.lisp (independent)
+```
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Guard verification complexity | High | Medium | Incremental development; prove type theorems early |
+| Block/label model mismatch with spec | Medium | High | Prototype with tests before committing to design |
+| Floating-point IEEE 754 complexity | High | Medium | Defer to late milestone; integer-only MVP |
+| ACL2 build time for large books | Medium | Low | Split into smaller books; parallel certification |
+| Parser-executor mismatch | Low | Medium | Test with concrete .wasm files early |
+| Termination proofs for recursive execution | Medium | Medium | Use step-count bounded `run` (already done) |
+| Existing skeleton API changes breaking proofs | Medium | Medium | Maintain backward compatibility; adapter layer |
+
+---
+
+## Definition of Done
+
+The formalization is **complete** when:
+1. ✅ All WASM 1.0 instructions have executable semantics
+2. ✅ All books certify (guards verified, theorems proven)
+3. ✅ At least 16 test programs execute correctly (assert-event)
+4. ✅ At least 3 non-trivial correctness proofs certified (defthm)
+5. ✅ A `.wasm` binary can be parsed and executed end-to-end
+6. ✅ The code integrates cleanly with existing Kestrel WASM books


### PR DESCRIPTION
## What

Adds a new example under `examples/wasm1-acl2-formalization-plan/` — an agent-generated plan for formalizing the WASM 1.0 operational semantics in ACL2, extending the [Kestrel Institute's WASM books](https://github.com/acl2/acl2/tree/master/books/kestrel/wasm).

## Files

| File | Description |
|---|---|
| `README.md` | Example metadata: model, task, verification commands, known gaps |
| `WASM1_PLAN.md` | 9-milestone plan from MVP (i32 arithmetic) to full formalization |
| `ACL2_SEMANTICS_REF.md` | SpecTec → ACL2 mapping, build reference, design notes |

## How it was produced

The agent:
1. Read all 10 WASM 1.0 SpecTec files (2300 lines of formal spec)
2. Read the existing Kestrel WASM skeleton + EVM and JVM models for patterns
3. Installed SBCL + built ACL2 8.7+
4. Certified all 3 existing Kestrel WASM books (`execution.lisp`, `add-proof.lisp`, `parse-binary.lisp`)
5. Ran a concrete execution test (`add(3,4)=7`) to validate the approach
6. Produced the plan and reference documents

## Example category

This is a **Generated Verified Code** example (specifically a formalization plan + reference), following the conventions in `examples/README.md`.

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@raymyers can click here to [continue refining the PR](https://staging.all-hands.dev/conversations/d28f8f92-a7e6-4e81-83ef-0243adf1bb70)