### PR TITLE
Add Derivative to agent frameworks and patterns

### DIFF
--- a/MORE_LINKS.md
+++ b/MORE_LINKS.md
@@ -132,6 +132,7 @@ See [README.md](./README.md) for curated highlights and project descriptions.
 - [Volcano SDK GitHub repo](https://github.com/Kong/volcano-sdk)
 - [Scaling data collection for training SWE agents](https://nebius.com/blog/posts/scaling-data-collection-for-training-swe-agents)
 - [Prompt engineering: bootstrapping with prompts](https://chip-hennig.medium.com/prompt-engineering-pulling-yourself-up-by-the-bootstraps-fc15c4a44d68)
+- [Derivative: requirement-to-software synthesis with typed requirement preservation, isolated execution, evidence-based validation, bounded repair, and fail-closed packaging](https://github.com/Daniele-Cangi/Derivative)
 
 ### MCP and Agent Protocols
 


### PR DESCRIPTION
Adds Derivative to MORE_LINKS under Agentic Software Craft > Agent Frameworks and Patterns. Its relevant contribution is a greenfield requirement-to-software pipeline with typed requirement preservation, isolated execution, independent evidence-based validation, bounded repair, and fail-closed packaging. This submission intentionally does not place Derivative among formally verified projects or claim formal verification.